### PR TITLE
Fix typo in Transactions document

### DIFF
--- a/docs/v3.1.9/resources-and-data-models/aisp/Transactions.md
+++ b/docs/v3.1.9/resources-and-data-models/aisp/Transactions.md
@@ -177,9 +177,9 @@ The resource differs depending on the permissions (ReadTransactionsBasic and Rea
   * OBReadTransaction6/Data/Transaction/DebtorAccount/Identification
   * OBReadTransaction6/Data/Transaction/CardInstrument/Identification
 
-* If the `ReadTransactionDebits` permission is granted by the PSU, the data returned should include credit transactions.
-* If the `ReadTransactionCredits` permission is granted by the PSU, the data returned should include debit transactions.
-* If the `ReadTransactionCredits` and `ReadTransactionDebits` permission is granted by the PSU, the data returned should include debit and credit transactions.
+* If the `ReadTransactionsDebits` permission is granted by the PSU, the data returned should include debit transactions.
+* If the `ReadTransactionsCredits` permission is granted by the PSU, the data returned should include credit transactions.
+* If the `ReadTransactionsCredits` and `ReadTransactionsDebits` permission is granted by the PSU, the data returned should include debit and credit transactions.
 
 
 


### PR DESCRIPTION
It looks like the [transactions document](https://github.com/OpenBankingUK/read-write-api-docs-pub/blob/master/docs/v3.1.9/resources-and-data-models/aisp/Transactions.md#permission-codes) might have a couple typos:

- `ReadTransactionDebits` and `ReadTransactionCredits` should be `ReadTransactionsDebits` and `ReadTransactionsCredits` ("Transactions" pluralized), respectively
- Based on [other documents](https://github.com/OpenBankingUK/read-write-api-docs-pub/blob/master/docs/v3.1.9/profiles/account-and-transaction-api-profile.md#permissions), I believe the "data returned" for the two permissions has been accidentally flipped.

This PR fixes both issues.